### PR TITLE
None was being printed

### DIFF
--- a/pytree.py
+++ b/pytree.py
@@ -22,6 +22,7 @@ def colorof(name: str, isdir: bool) -> str:
         for pat, col in COLORS.items():
             if fnmatch.fnmatch(name, pat):
                 return col
+        return ""
 
 
 def printnode(depth: int, name: str, isdir: bool):


### PR DESCRIPTION
`None` was partially printed when no color entry pattern matched in `colorof`.